### PR TITLE
update gateway routes to use Eureka load balancing

### DIFF
--- a/gatewayserver/src/main/java/gateway/proximity/gatewayserver/config/GatewayConfig.java
+++ b/gatewayserver/src/main/java/gateway/proximity/gatewayserver/config/GatewayConfig.java
@@ -12,10 +12,6 @@ import org.springframework.context.annotation.Configuration;
 public class GatewayConfig {
 
     private final AuthenticationFilter authFilter;
-    @Value("${management-service-url}")
-    private String managementServiceUrl;
-    @Value("${provider-profile-url}")
-    private  String providerProfileServiceUrl;
 
     public GatewayConfig(AuthenticationFilter authFilter) {
         this.authFilter = authFilter;
@@ -26,7 +22,7 @@ public class GatewayConfig {
         return builder.routes()
             .route("provider-profile-service", r -> r.path("/api/v1/**")
                 .filters(f -> f.filter(authFilter.apply(new AuthenticationFilter.Config())))
-                .uri(providerProfileServiceUrl))
+                .uri("lb://service-provider-profile"))
             
 
             .build();
@@ -37,8 +33,7 @@ public class GatewayConfig {
         return builder.routes()
                 .route("management-service", r -> r.path("/api/v1/**")
                         .filters(f -> f.filter(authFilter.apply(new AuthenticationFilter.Config())))
-                        .uri(managementServiceUrl))
-
+                        .uri("lb://management"))
 
                 .build();
     }

--- a/gatewayserver/src/main/resources/application-prod.yml
+++ b/gatewayserver/src/main/resources/application-prod.yml
@@ -60,7 +60,4 @@ server:
   port: ${SERVER_PORT:8888}
 
 
-provider-profile-url: ${PROVIDER_PROFILE_SERVICE_URL}
-
-management-service-url: ${MANAGEMENT_SERVICE_URL}
 


### PR DESCRIPTION
This PR updates the routing logic in the GatewayConfig class to use Eureka-based load balancing for service discovery, replacing the hardcoded service URLs with dynamic load-balanced routes.
Changes:

**Key Changes**

1. Replaced the static service URLs (providerProfileServiceUrl and managementServiceUrl) with lb:// URIs for dynamic routing.

2. Configured the Spring Cloud Gateway to use Eureka load balancing for routing requests to the provider-profile-service and management-service.


**Why**

1. This change ensures that the gateway dynamically resolves and routes requests to the available instances of the services registered in Eureka, improving scalability and resilience.

2.  By using load balancing, we reduce dependency on hardcoded URLs and allow for better service discovery and fault tolerance.