### PR TITLE
remove security restriction on contact support endpoint

### DIFF
--- a/help-and-support/src/main/java/team/proximity/helpandsupport/security/SecurityConfiguration.java
+++ b/help-and-support/src/main/java/team/proximity/helpandsupport/security/SecurityConfiguration.java
@@ -38,7 +38,7 @@ public class SecurityConfiguration {
                                 "/api/v1/support/faq-groups/**")
                         .permitAll()
                         .requestMatchers(HttpMethod.POST,
-                                "/api/v1/support/contact-support").anonymous()
+                                "/api/v1/support/contact-support").permitAll()
 
                         .requestMatchers(HttpMethod.POST,
 


### PR DESCRIPTION
This update removes security restrictions on the contact-support endpoint, allowing it to be accessed by all users without authentication. The change replaces the anonymous() configuration with permitAll()