### PR TITLE
add route for quote-service

### DIFF
--- a/gatewayserver/src/main/java/gateway/proximity/gatewayserver/config/GatewayConfig.java
+++ b/gatewayserver/src/main/java/gateway/proximity/gatewayserver/config/GatewayConfig.java
@@ -34,6 +34,10 @@ public class GatewayConfig {
                         .filters(f -> f.filter(authFilter.apply(new AuthenticationFilter.Config())))
                         .uri("lb://MANAGEMENT"))
 
+                .route("quote-service", r -> r.path("/api/v1/quote-service/**")
+                        .filters(f -> f.filter(authFilter.apply(new AuthenticationFilter.Config())))
+                        .uri("lb://REQUEST-MANAGEMENT-SERVICE"))
+
                 .build();
     }
 }


### PR DESCRIPTION
This PR updates the gateway routing configuration to include a new route for the quote-service. The quote-service route has been added to ensure that requests to /api/v1/quote-service/** are routed correctly through the gateway and passed to the REQUEST-MANAGEMENT-SERVICE service